### PR TITLE
Allow duplicate urls

### DIFF
--- a/src/wstore/asset_manager/asset_manager.py
+++ b/src/wstore/asset_manager/asset_manager.py
@@ -187,7 +187,8 @@ class AssetManager:
         provided_as = 'FILE'
         if 'content' in data:
             if isinstance(data['content'], str) or isinstance(data['content'], unicode):
-                self._check_url_conflict(data, current_organization)
+                #We want to allow duplicate URLs as assets
+                #self._check_url_conflict(data, current_organization)
 
                 download_link = data['content']
                 provided_as = 'URL'

--- a/src/wstore/asset_manager/asset_manager.py
+++ b/src/wstore/asset_manager/asset_manager.py
@@ -187,9 +187,7 @@ class AssetManager:
         provided_as = 'FILE'
         if 'content' in data:
             if isinstance(data['content'], str) or isinstance(data['content'], unicode):
-                #We want to allow duplicate URLs as assets
-                #self._check_url_conflict(data, current_organization)
-
+                
                 download_link = data['content']
                 provided_as = 'URL'
 

--- a/src/wstore/asset_manager/test/asset_manager_tests.py
+++ b/src/wstore/asset_manager/test/asset_manager_tests.py
@@ -361,7 +361,6 @@ class UploadAssetTestCase(TestCase):
         }, am.rollback_logger)
 
         # Check calls
-        #asset_manager.Resource.objects.filter.assert_called_once_with(download_link=self.LINK, provider=self._user.userprofile.current_organization)
         asset_manager.ResourcePlugin.objects.filter.assert_called_once_with(name='service')
 
         # Check resource creation
@@ -377,28 +376,7 @@ class UploadAssetTestCase(TestCase):
             meta_info=exp_meta
         )
 
-    """ def test_upload_asset_pending(self):
-        content = deepcopy(self.LINK_CONTENT)
-        content['metadata'] = self.BASIC_META
-
-        self._mock_resource_type(self.BASIC_FORM)
-
-        am = asset_manager.AssetManager()
-        am.rollback_logger = {
-            'files': [],
-            'models': []
-        }
-
-        assets = [MagicMock(product_id=None), MagicMock(product_id=None)]
-        asset_manager.Resource.objects.filter.return_value = assets
-        am.upload_asset(self._user, content)
-
-        # Check calls
-        asset_manager.Resource.objects.filter.assert_called_once_with(
-            download_link=self.LINK, provider=self._user.userprofile.current_organization)
-        
-        assets[0].delete.assert_called_once_with()
-        assets[1].delete.assert_called_once_with() """
+    
 
     def _existing_asset(self):
         asset_manager.Resource.objects.filter.return_value = [MagicMock(product_id='1')]

--- a/src/wstore/asset_manager/test/asset_manager_tests.py
+++ b/src/wstore/asset_manager/test/asset_manager_tests.py
@@ -361,7 +361,7 @@ class UploadAssetTestCase(TestCase):
         }, am.rollback_logger)
 
         # Check calls
-        asset_manager.Resource.objects.filter.assert_called_once_with(download_link=self.LINK, provider=self._user.userprofile.current_organization)
+        #asset_manager.Resource.objects.filter.assert_called_once_with(download_link=self.LINK, provider=self._user.userprofile.current_organization)
         asset_manager.ResourcePlugin.objects.filter.assert_called_once_with(name='service')
 
         # Check resource creation
@@ -377,7 +377,7 @@ class UploadAssetTestCase(TestCase):
             meta_info=exp_meta
         )
 
-    def test_upload_asset_pending(self):
+    """ def test_upload_asset_pending(self):
         content = deepcopy(self.LINK_CONTENT)
         content['metadata'] = self.BASIC_META
 
@@ -396,9 +396,9 @@ class UploadAssetTestCase(TestCase):
         # Check calls
         asset_manager.Resource.objects.filter.assert_called_once_with(
             download_link=self.LINK, provider=self._user.userprofile.current_organization)
-
+        
         assets[0].delete.assert_called_once_with()
-        assets[1].delete.assert_called_once_with()
+        assets[1].delete.assert_called_once_with() """
 
     def _existing_asset(self):
         asset_manager.Resource.objects.filter.return_value = [MagicMock(product_id='1')]


### PR DESCRIPTION
Since fiware services are used to handle multi-tenancy, the same endpoint can be used for different data streams (e.g. BikeHireDockingStation in Santander and BikeHireDockingStation in Manchester).
Previously there was a check in the frontend that prevents data assets to have the same endpoint, this needed to be changed.